### PR TITLE
Update scroll to be an unsigned int

### DIFF
--- a/LED Episode 06/src/marquee.h
+++ b/LED Episode 06/src/marquee.h
@@ -57,7 +57,7 @@ void DrawMarqueeMirrored()
     }
 
 
-    static int scroll = 0;
+    static unsigned int scroll = 0;
     scroll++;
 
     for (int i = scroll % 5; i < NUM_LEDS / 2; i += 5)


### PR DESCRIPTION
scroll needs to be an unsigned integer... otherwise, it'll roll over to a negative value and 'wreak havoc' when updating the LED array in the subsequent loop.  On a 32-bit processor, the int value will range from +2^31-1 top -2^31, so the rollover won't occur for a LONG time.  However, on a number of Arduino platforms, the int value will only be 16-bits... so it'll roll at 32K iterations.

(I commented in the YouTube video but decided to come here as well to propose the change.)

Cheers,
Dave